### PR TITLE
Add AGENTS.md with project principles and contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Project Overview
+
+Little Wins Together is a calm support community for parents raising children with autism. The product should feel supportive, emotionally safe, and human rather than corporate, flashy, or growth-driven.
+
+## Core Product Principles
+
+- Build a support-first experience for parents and caregivers.
+- Keep the UI calm, emotionally safe, and reassuring.
+- Avoid flashy startup aesthetics, loud visuals, and high-pressure language.
+- Avoid gamification, leaderboards, streaks, badges, or competitive mechanics.
+- Avoid engagement bait patterns such as urgency loops, manipulative notifications, or infinite-scroll dopamine feeds.
+- Prioritize readability and accessibility in copy, layout, contrast, focus states, and interaction design.
+- Use generous whitespace and spacious layouts.
+- Prefer stacked conversation layouts over dense feeds.
+- Public users should be able to read discussions.
+- Posting and replying should require authenticated accounts.
+
+## Design Principles
+
+- Use soft blue accents as the primary visual tone.
+- Prefer rounded cards, gentle borders, and subtle shadows.
+- Use calm typography with clear hierarchy and comfortable line lengths.
+- Keep navigation minimal and easy to understand.
+- Avoid overwhelming interfaces, cluttered screens, and unnecessary controls.
+- Design for quiet reassurance rather than urgency.
+
+## Technical Guidance
+
+- Use Next.js App Router patterns.
+- Write TypeScript for application code.
+- Use TailwindCSS for styling.
+- Keep dependencies minimal and avoid adding libraries unless they clearly support the MVP.
+- Prefer reusable components when a pattern is repeated.
+- Avoid unnecessary abstraction early; keep code readable and direct.
+- Keep MVP architecture simple and easy to evolve.
+- Do not introduce features outside the current MVP unless explicitly requested.
+
+## Community Principles
+
+- Encourage supportive, respectful interactions.
+- Preserve transparency around edited posts and replies when edit functionality exists.
+- Do not present medical or legal advice as fact.
+- Support optional location tags for region-specific discussions.
+- Use language that is warm, clear, and non-judgmental.
+
+## Workflow Expectations
+
+- Summarize files changed after each task.
+- Explain routing changes, including new routes, changed route behavior, or navigation updates.
+- Explain how to preview and test changes.
+- Avoid modifying unrelated files.
+- Keep changes focused on the requested task.


### PR DESCRIPTION
### Motivation
- Document the project's product, design, technical, community, and workflow principles to provide clear guidance for contributors and future development.

### Description
- Add `AGENTS.md` containing the project overview, core product and design principles, technical guidance, community principles, and workflow expectations.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5739da6083248f2242447ed5c582)