### PR TITLE
Add Conversations and Sign-In pages, update navigation links, and bump deps

### DIFF
--- a/web/app/conversations/page.tsx
+++ b/web/app/conversations/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export default function ConversationsPage() {
+  return (
+    <main className="py-16">
+      <section className="rounded-3xl bg-white/80 p-10 shadow-sm ring-1 ring-calm-100">
+        <div className="max-w-2xl space-y-5">
+          <p className="text-sm font-medium text-calm-700">Conversations</p>
+          <div className="space-y-3">
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-900">
+              Browse Conversations
+            </h1>
+            <p className="text-base leading-relaxed text-slate-700">
+              Public conversations are coming soon. This will be a calm place to read community discussions before signing in to post or reply.
+            </p>
+          </div>
+          <Link
+            href="/signin"
+            className="inline-flex rounded-full bg-calm-500 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-calm-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-calm-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          >
+            Join the Community
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -15,22 +16,25 @@ export default function RootLayout(props: { children: React.ReactNode }) {
         <div className="mx-auto flex min-h-screen max-w-5xl flex-col px-4">
           <header className="pt-4 border-b border-white/60">
             <nav className="flex items-center justify-between text-sm text-slate-600">
-              <span className="font-medium text-slate-800">
+              <Link
+                href="/"
+                className="rounded-full px-3 py-1 text-sm font-medium text-calm-700 transition-colors hover:bg-white/60 hover:text-calm-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-calm-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              >
                 Little Wins Together
-              </span>
+              </Link>
               <div className="flex items-center gap-4">
-                <button
-                  type="button"
+                <Link
+                  href="/conversations"
                   className="rounded-full px-3 py-1 text-sm text-slate-600 transition-colors hover:bg-white/60 hover:text-calm-700"
                 >
                   Browse Conversations
-                </button>
-                <button
-                  type="button"
+                </Link>
+                <Link
+                  href="/signin"
                   className="rounded-full px-3 py-1 text-sm text-slate-600 transition-colors hover:bg-white/60 hover:text-calm-700"
                 >
                   Sign In
-                </button>
+                </Link>
               </div>
             </nav>
           </header>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 const HERO_HEADLINE = "Celebrate Every Little Win Together";
 const HERO_SUBHEADING = "A supportive community for parents raising children with autism.";
 const PRIMARY_CTA = "Join the Community";
@@ -23,18 +25,18 @@ export default function HomePage() {
               {HERO_SUBHEADING}
             </p>
             <div className="flex flex-wrap gap-3 pt-2">
-              <button
-                type="button"
+              <Link
+                href="/signin"
                 className="rounded-full bg-calm-500 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-calm-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-calm-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 {PRIMARY_CTA}
-              </button>
-              <button
-                type="button"
+              </Link>
+              <Link
+                href="/conversations"
                 className="rounded-full border border-calm-100 bg-white px-5 py-2.5 text-sm font-medium text-calm-700 transition-colors hover:border-calm-200 hover:bg-calm-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-calm-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 {SECONDARY_CTA}
-              </button>
+              </Link>
             </div>
           </div>
         </section>

--- a/web/app/signin/page.tsx
+++ b/web/app/signin/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export default function SignInPage() {
+  return (
+    <main className="flex flex-1 items-center justify-center py-20">
+      <section className="w-full max-w-2xl rounded-3xl bg-white/80 p-10 shadow-sm ring-1 ring-calm-100">
+        <div className="space-y-5">
+          <p className="text-sm font-medium text-calm-700">Little Wins Together</p>
+          <div className="space-y-3">
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-900">
+              Sign In
+            </h1>
+            <p className="text-base leading-relaxed text-slate-700">
+              Account access is coming soon. Soon you&rsquo;ll be able to join the community, post conversations, and reply with a display name.
+            </p>
+          </div>
+          <Link
+            href="/conversations"
+            className="inline-flex rounded-full border border-calm-100 bg-white px-5 py-2.5 text-sm font-medium text-calm-700 transition-colors hover:border-calm-200 hover:bg-calm-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-calm-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          >
+            Browse Conversations
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,9 +8,10 @@
       "name": "little-wins-together-web",
       "version": "0.1.0",
       "dependencies": {
-        "next": "^14",
-        "react": "^18",
-        "react-dom": "^18"
+        "@supabase/supabase-js": "^2.57.2",
+        "next": "^14.2.35",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@types/node": "^20",

--- a/web/package.json
+++ b/web/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
-  "next": "^14",
-  "react": "^18",
-  "react-dom": "^18"
-},
+    "@supabase/supabase-js": "^2.57.2",
+    "next": "^14.2.35",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
   "devDependencies": {
-  "@types/node": "^20",
-  "@types/react": "^18",
-  "@types/react-dom": "^18",
-  "autoprefixer": "^10.4.20",
-  "eslint": "^8",
-  "eslint-config-next": "^14",
-  "postcss": "^8.4.49",
-  "tailwindcss": "^3.4.17",
-  "typescript": "^5"
-}
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8",
+    "eslint-config-next": "^14",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5"
+  }
 }

--- a/web/postcss.config.mjs
+++ b/web/postcss.config.mjs
@@ -1,5 +1,6 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
+    tailwindcss: {},
+    autoprefixer: {},
   },
 };

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -12,7 +12,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
### Motivation
- Provide public-facing placeholder pages for browsing conversations and signing in to encourage community engagement. 
- Replace header action buttons with Next.js `Link` components so navigation uses client-side routing. 
- Prepare the project for updated toolchain and features by bumping Next/React versions and adding `@supabase/supabase-js` and PostCSS adjustments.

### Description
- Added `web/app/conversations/page.tsx` and `web/app/signin/page.tsx` as placeholder pages with CTAs and explanatory copy. 
- Updated `web/app/layout.tsx` and `web/app/page.tsx` to import and use `next/link` for the site title, navigation items, and primary/secondary CTAs. 
- Updated `web/package.json` and `web/package-lock.json` to bump `next`, `react`, and `react-dom` versions and add `@supabase/supabase-js`. 
- Adjusted `web/postcss.config.mjs` to enable `tailwindcss` and `autoprefixer`, and changed `web/tsconfig.json` `moduleResolution` to `Bundler`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5739da6083248f2242447ed5c582)